### PR TITLE
Retrieve on-call user per escalation policy.

### DIFF
--- a/app/models/alerting_step.rb
+++ b/app/models/alerting_step.rb
@@ -2,6 +2,12 @@ class AlertingStep < ActiveRecord::Base
   belongs_to :contact_detail
   belongs_to :rotation_membership
 
+  validates :delay, :numericality => {
+    :only_integer => true,
+    :greater_than_or_equal_to => 0
+  }
   validates :contact_detail_id, :presence => true
   validates :rotation_membership_id, :presence => true
+
+  scope :ordered, order("delay")
 end

--- a/app/models/alerting_step.rb
+++ b/app/models/alerting_step.rb
@@ -2,12 +2,12 @@ class AlertingStep < ActiveRecord::Base
   belongs_to :contact_detail
   belongs_to :rotation_membership
 
-  validates :delay, :numericality => {
+  validates :delay_minutes, :numericality => {
     :only_integer => true,
     :greater_than_or_equal_to => 0
   }
   validates :contact_detail_id, :presence => true
   validates :rotation_membership_id, :presence => true
 
-  scope :ordered, order("delay")
+  scope :ordered, order("delay_minutes")
 end

--- a/app/models/escalation_policy.rb
+++ b/app/models/escalation_policy.rb
@@ -6,9 +6,7 @@ class EscalationPolicy < ActiveRecord::Base
 
   def oncall(issue)
     delay = (Time.now - issue.posted_at) / 60
-    step = escalation_steps.ordered.find_all { |step|
-      step.delay_minutes < delay
-    }.last
+    step = escalation_steps.active_after(delay).last
     step.rotation.users.first
   end
 end

--- a/app/models/escalation_policy.rb
+++ b/app/models/escalation_policy.rb
@@ -3,4 +3,12 @@ class EscalationPolicy < ActiveRecord::Base
   has_many :issues
 
   validates :name, :presence => true
+
+  def oncall
+    step = escalation_steps.ordered.first
+    # TODO(hermannloose): Should make sure there's always at least one step.
+    unless step.nil?
+      step.rotation.users.first
+    end
+  end
 end

--- a/app/models/escalation_policy.rb
+++ b/app/models/escalation_policy.rb
@@ -4,11 +4,11 @@ class EscalationPolicy < ActiveRecord::Base
 
   validates :name, :presence => true
 
-  def oncall
-    step = escalation_steps.ordered.first
-    # TODO(hermannloose): Should make sure there's always at least one step.
-    unless step.nil?
-      step.rotation.users.first
-    end
+  def oncall(issue)
+    delay = (Time.now - issue.posted_at) / 60
+    step = escalation_steps.ordered.find_all { |step|
+      step.delay_minutes < delay
+    }.last
+    step.rotation.users.first
   end
 end

--- a/app/models/escalation_step.rb
+++ b/app/models/escalation_step.rb
@@ -1,6 +1,8 @@
 class EscalationStep < ActiveRecord::Base
+  belongs_to :escalation_policy
   belongs_to :rotation
 
   validates :delay, :numericality => { :only_integer => true, :greater_than_or_equal_to => 0 }
+  validates :escalation_policy_id, :presence => true
   validates :rotation_id, :presence => true
 end

--- a/app/models/escalation_step.rb
+++ b/app/models/escalation_step.rb
@@ -2,9 +2,12 @@ class EscalationStep < ActiveRecord::Base
   belongs_to :escalation_policy
   belongs_to :rotation
 
-  validates :delay, :numericality => { :only_integer => true, :greater_than_or_equal_to => 0 }
+  validates :delay_minutes, :numericality => {
+    :only_integer => true,
+    :greater_than_or_equal_to => 0
+  }
   validates :escalation_policy_id, :presence => true
   validates :rotation_id, :presence => true
 
-  scope :ordered, order("delay")
+  scope :ordered, order("delay_minutes")
 end

--- a/app/models/escalation_step.rb
+++ b/app/models/escalation_step.rb
@@ -5,4 +5,6 @@ class EscalationStep < ActiveRecord::Base
   validates :delay, :numericality => { :only_integer => true, :greater_than_or_equal_to => 0 }
   validates :escalation_policy_id, :presence => true
   validates :rotation_id, :presence => true
+
+  scope :ordered, order("delay")
 end

--- a/app/models/escalation_step.rb
+++ b/app/models/escalation_step.rb
@@ -10,4 +10,7 @@ class EscalationStep < ActiveRecord::Base
   validates :rotation_id, :presence => true
 
   scope :ordered, order("delay_minutes")
+  scope :active_after, lambda { |minutes|
+    ordered.where("delay_minutes < #{minutes}")
+  }
 end

--- a/app/models/rotation.rb
+++ b/app/models/rotation.rb
@@ -1,6 +1,6 @@
 class Rotation < ActiveRecord::Base
   has_many :rotation_memberships
-  has_many :users, :through => :rotation_memberships
+  has_many :users, :through => :rotation_memberships, :order => "rank"
 
   validates :name, :presence => true
 end

--- a/app/models/rotation_membership.rb
+++ b/app/models/rotation_membership.rb
@@ -3,6 +3,12 @@ class RotationMembership < ActiveRecord::Base
   belongs_to :user
   has_many :alerting_steps
 
+  validates :rank, :numericality => {
+    :only_integer => true,
+    :greater_than_or_equal_to => 0
+  }
   validates :rotation_id, :presence => true
   validates :user_id, :presence => true
+
+  scope :ordered, order("rank")
 end

--- a/db/migrate/20120111111756_add_escalation_policy_to_escalation_step.rb
+++ b/db/migrate/20120111111756_add_escalation_policy_to_escalation_step.rb
@@ -1,0 +1,8 @@
+class AddEscalationPolicyToEscalationStep < ActiveRecord::Migration
+  def change
+    change_table :escalation_steps do |t|
+      t.references :escalation_policy
+      t.index :escalation_policy_id
+    end
+  end
+end

--- a/db/migrate/20120111211847_rename_delay_columns.rb
+++ b/db/migrate/20120111211847_rename_delay_columns.rb
@@ -1,0 +1,11 @@
+class RenameDelayColumns < ActiveRecord::Migration
+  def change
+    change_table :alerting_steps do |t|
+      t.rename :delay, :delay_minutes
+    end
+
+    change_table :escalation_steps do |t|
+      t.rename :delay, :delay_minutes
+    end
+  end
+end

--- a/db/migrate/20120112115301_add_rank_to_rotation_memberships.rb
+++ b/db/migrate/20120112115301_add_rank_to_rotation_memberships.rb
@@ -1,0 +1,5 @@
+class AddRankToRotationMemberships < ActiveRecord::Migration
+  def change
+    add_column :rotation_memberships, :rank, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20120111211847) do
+ActiveRecord::Schema.define(:version => 20120112115301) do
 
   create_table "alerting_steps", :force => true do |t|
     t.integer  "delay_minutes"
@@ -94,6 +94,7 @@ ActiveRecord::Schema.define(:version => 20120111211847) do
     t.integer  "user_id"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.integer  "rank"
   end
 
   add_index "rotation_memberships", ["rotation_id"], :name => "index_rotation_memberships_on_rotation_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,10 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20120111111756) do
+ActiveRecord::Schema.define(:version => 20120111211847) do
 
   create_table "alerting_steps", :force => true do |t|
-    t.integer  "delay"
+    t.integer  "delay_minutes"
     t.integer  "contact_detail_id"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -67,7 +67,7 @@ ActiveRecord::Schema.define(:version => 20120111111756) do
   end
 
   create_table "escalation_steps", :force => true do |t|
-    t.integer  "delay"
+    t.integer  "delay_minutes"
     t.integer  "rotation_id"
     t.datetime "created_at"
     t.datetime "updated_at"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20120110135847) do
+ActiveRecord::Schema.define(:version => 20120111111756) do
 
   create_table "alerting_steps", :force => true do |t|
     t.integer  "delay"
@@ -71,8 +71,10 @@ ActiveRecord::Schema.define(:version => 20120110135847) do
     t.integer  "rotation_id"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.integer  "escalation_policy_id"
   end
 
+  add_index "escalation_steps", ["escalation_policy_id"], :name => "index_escalation_steps_on_escalation_policy_id"
   add_index "escalation_steps", ["rotation_id"], :name => "index_escalation_steps_on_rotation_id"
 
   create_table "issues", :force => true do |t|

--- a/test/fixtures/alerting_steps.yml
+++ b/test/fixtures/alerting_steps.yml
@@ -1,16 +1,16 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/Fixtures.html
 
 valid:
-  delay: 1
+  delay_minutes: 1
   contact_detail: valid
   rotation_membership: valid
 
 one:
-  delay: 1
+  delay_minutes: 1
   contact_detail: 
   rotation_membership: 
 
 two:
-  delay: 1
+  delay_minutes: 1
   contact_detail: 
   rotation_membership: 

--- a/test/fixtures/escalation_steps.yml
+++ b/test/fixtures/escalation_steps.yml
@@ -11,11 +11,6 @@ valid:
   rotation: one
 
 1-2:
-  delay_minutes: 500
+  delay_minutes: 3
   escalation_policy: one
-  rotation: one
-
-1-3:
-  delay_minutes: 250
-  escalation_policy: one
-  rotation: one
+  rotation: two

--- a/test/fixtures/escalation_steps.yml
+++ b/test/fixtures/escalation_steps.yml
@@ -2,12 +2,20 @@
 
 valid:
   delay: 1
+  escalation_policy: valid
   rotation: valid
 
-one:
-  delay: 1
-  rotation: 
+1-1:
+  delay: 0
+  escalation_policy: one
+  rotation: valid
 
-two:
-  delay: 1
-  rotation: 
+1-2:
+  delay: 500
+  escalation_policy: one
+  rotation: valid
+
+1-3:
+  delay: 250
+  escalation_policy: one
+  rotation: valid

--- a/test/fixtures/escalation_steps.yml
+++ b/test/fixtures/escalation_steps.yml
@@ -1,21 +1,21 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/Fixtures.html
 
 valid:
-  delay: 1
+  delay_minutes: 1
   escalation_policy: valid
   rotation: valid
 
 1-1:
-  delay: 0
+  delay_minutes: 0
   escalation_policy: one
   rotation: one
 
 1-2:
-  delay: 500
+  delay_minutes: 500
   escalation_policy: one
   rotation: one
 
 1-3:
-  delay: 250
+  delay_minutes: 250
   escalation_policy: one
   rotation: one

--- a/test/fixtures/escalation_steps.yml
+++ b/test/fixtures/escalation_steps.yml
@@ -8,14 +8,14 @@ valid:
 1-1:
   delay: 0
   escalation_policy: one
-  rotation: valid
+  rotation: one
 
 1-2:
   delay: 500
   escalation_policy: one
-  rotation: valid
+  rotation: one
 
 1-3:
   delay: 250
   escalation_policy: one
-  rotation: valid
+  rotation: one

--- a/test/fixtures/issues.yml
+++ b/test/fixtures/issues.yml
@@ -4,33 +4,33 @@ valid:
   escalation_policy: valid
   title: present
   description: 
-  posted_at: 
+  posted_at: <%= 1.minutes.ago %>
   status: present
 
 1-1:
-  escalation_policy: policy1
+  escalation_policy: one
   title: issue 1-1
   description: 
-  posted_at: 2011-12-22 20:58:59
+  posted_at: <%= 1.minutes.ago %>
   status: new
 
 1-2:
-  escalation_policy: policy1
+  escalation_policy: one
   title: issue 1-2
   description: 
-  posted_at: 2011-12-22 20:58:59
+  posted_at: <%= 5.minutes.ago %>
   status: new
 
 2-1:
-  escalation_policy: policy2
+  escalation_policy: two
   title: issue 2-1
   description: 
-  posted_at: 2011-12-22 20:58:59
+  posted_at: <%= 1.minutes.ago %>
   status: new
 
 2-2:
-  escalation_policy: policy2
+  escalation_policy: two
   title: issue 2-2
   description: 
-  posted_at: 2011-12-22 20:58:59
+  posted_at: <%= 5.minutes.ago %>
   status: new

--- a/test/fixtures/rotation_memberships.yml
+++ b/test/fixtures/rotation_memberships.yml
@@ -3,21 +3,24 @@
 valid:
   rotation: valid
   user: valid
+  rank: 0
 
 1-1:
   rotation: one
   user: one
+  rank: 0
 
 1-2:
   rotation: one
   user: two
+  rank: 1
 
-# FIXME: Add explicit order/rank, as this is broken right now.
-# (can be fixed temporarily by swapping the ids ("2-2" <-> "2-3")
 2-2:
   rotation: two
   user: two
+  rank: 0
 
 2-3:
   rotation: two
   user: three
+  rank: 1

--- a/test/fixtures/rotation_memberships.yml
+++ b/test/fixtures/rotation_memberships.yml
@@ -12,10 +12,12 @@ valid:
   rotation: one
   user: two
 
-2-1:
-  rotation: two
-  user: one
-
+# FIXME: Add explicit order/rank, as this is broken right now.
+# (can be fixed temporarily by swapping the ids ("2-2" <-> "2-3")
 2-2:
   rotation: two
   user: two
+
+2-3:
+  rotation: two
+  user: three

--- a/test/fixtures/rotation_memberships.yml
+++ b/test/fixtures/rotation_memberships.yml
@@ -4,10 +4,18 @@ valid:
   rotation: valid
   user: valid
 
-one:
-  rotation: 
-  user: 
+1-1:
+  rotation: one
+  user: one
 
-two:
-  rotation: 
-  user: 
+1-2:
+  rotation: one
+  user: two
+
+2-1:
+  rotation: two
+  user: one
+
+2-2:
+  rotation: two
+  user: two

--- a/test/fixtures/rotations.yml
+++ b/test/fixtures/rotations.yml
@@ -4,7 +4,7 @@ valid:
   name: present
 
 one:
-  name: MyString
+  name: rotation one
 
 two:
-  name: MyString
+  name: rotation two

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -6,11 +6,16 @@ valid:
   is_admin: false
 
 one:
-  name: MyString
-  email: MyString
+  name: User 1
+  email: user1@example.com
   is_admin: false
 
 two:
-  name: MyString
-  email: MyString
+  name: User 2
+  email: user2@example.com
+  is_admin: false
+
+three:
+  name: User 3
+  email: user3@example.com
   is_admin: false

--- a/test/unit/alerting_step_test.rb
+++ b/test/unit/alerting_step_test.rb
@@ -9,6 +9,21 @@ class AlertingStepTest < ActiveSupport::TestCase
     assert @step.save
   end
 
+  test "should allow a delay of zero" do
+    @step.delay = 0
+    assert @step.save
+  end
+
+  test "should not allow negative delays" do
+    @step.delay = -1
+    assert !@step.save
+  end
+
+  test "should only allow integer delays" do
+    @step.delay = 1.1
+    assert !@step.save
+  end
+
   test "should validate presence of contact_detail" do
     @step.contact_detail = nil
     assert !@step.save

--- a/test/unit/alerting_step_test.rb
+++ b/test/unit/alerting_step_test.rb
@@ -10,17 +10,17 @@ class AlertingStepTest < ActiveSupport::TestCase
   end
 
   test "should allow a delay of zero" do
-    @step.delay = 0
+    @step.delay_minutes = 0
     assert @step.save
   end
 
   test "should not allow negative delays" do
-    @step.delay = -1
+    @step.delay_minutes = -1
     assert !@step.save
   end
 
   test "should only allow integer delays" do
-    @step.delay = 1.1
+    @step.delay_minutes = 1.1
     assert !@step.save
   end
 

--- a/test/unit/escalation_policy_test.rb
+++ b/test/unit/escalation_policy_test.rb
@@ -13,4 +13,8 @@ class EscalationPolicyTest < ActiveSupport::TestCase
     @policy.name = nil
     assert !@policy.save
   end
+
+  test "should get current on-call user" do
+    assert escalation_policies(:one).oncall == users(:one)
+  end
 end

--- a/test/unit/escalation_policy_test.rb
+++ b/test/unit/escalation_policy_test.rb
@@ -5,7 +5,7 @@ class EscalationPolicyTest < ActiveSupport::TestCase
     @policy = escalation_policies(:valid)
   end
 
-  test "should save valid escalation poliy" do
+  test "should save valid escalation policy" do
     assert @policy.save
   end
 

--- a/test/unit/escalation_policy_test.rb
+++ b/test/unit/escalation_policy_test.rb
@@ -15,6 +15,9 @@ class EscalationPolicyTest < ActiveSupport::TestCase
   end
 
   test "should get current on-call user" do
-    assert escalation_policies(:one).oncall == users(:one)
+    issue1 = issues("1-1")
+    issue2 = issues("1-2")
+    assert_equal users(:one), escalation_policies(:one).oncall(issue1)
+    assert_equal users(:two), escalation_policies(:one).oncall(issue2)
   end
 end

--- a/test/unit/escalation_step_test.rb
+++ b/test/unit/escalation_step_test.rb
@@ -24,6 +24,11 @@ class EscalationStepTest < ActiveSupport::TestCase
     assert !@step.save
   end
 
+  test "should validate presence of escalation_policy" do
+    @step.escalation_policy = nil
+    assert !@step.save
+  end
+
   test "should validate presence of rotation" do
     @step.rotation = nil
     assert !@step.save

--- a/test/unit/escalation_step_test.rb
+++ b/test/unit/escalation_step_test.rb
@@ -10,17 +10,17 @@ class EscalationStepTest < ActiveSupport::TestCase
   end
 
   test "should allow a delay of zero" do
-    @step.delay = 0
+    @step.delay_minutes = 0
     assert @step.save
   end
 
   test "should not allow negative delays" do
-    @step.delay = -1
+    @step.delay_minutes = -1
     assert !@step.save
   end
 
   test "should only allow integer delays" do
-    @step.delay = 1.1
+    @step.delay_minutes = 1.1
     assert !@step.save
   end
 

--- a/test/unit/rotation_test.rb
+++ b/test/unit/rotation_test.rb
@@ -13,4 +13,15 @@ class RotationTest < ActiveSupport::TestCase
     @rotation.name = nil
     assert !@rotation.save
   end
+
+  test "should order users by rank" do
+    user1 = users(:one)
+    user2 = users(:two)
+    user3 = users(:three)
+    rotation1 = rotations(:one)
+    rotation2 = rotations(:two)
+
+    assert_equal [user1, user2], rotation1.users
+    assert_equal [user2, user3], rotation2.users
+  end
 end


### PR DESCRIPTION
For now this lives in the EscalationPolicy itself, though it should probably be factored out. The on-call is the first user in the rotation associated with the last escalation step that became "active", i.e. that has the highest delay still smaller than the delay between when the given issue was posted and the current time.
