### PR TITLE
Add simple notification mailer.

### DIFF
--- a/app/mailers/assignee_mailer.rb
+++ b/app/mailers/assignee_mailer.rb
@@ -10,4 +10,13 @@ class AssigneeMailer < ActionMailer::Base
         :subject => "Issue #{@issue.to_param} has been assigned to you!")
 
   end
+
+  def escalated_mail(user, issue)
+    @user = user
+    @issue = issue
+
+    mail(:to => @user.email,
+        :subject => "Issue #{@issue.to_param} has been escalated!")
+
+  end
 end

--- a/app/mailers/assignee_mailer.rb
+++ b/app/mailers/assignee_mailer.rb
@@ -1,0 +1,13 @@
+class AssigneeMailer < ActionMailer::Base
+  default :from => "escalator@localhost"
+
+  def assignee_mail(user, issue, time_left=nil)
+    @user = user
+    @issue = issue
+    @time_left = time_left
+
+    mail(:to => @user.email,
+        :subject => "Issue #{@issue.to_param} has been assigned to you!")
+
+  end
+end

--- a/app/views/assignee_mailer/assignee_mail.text.erb
+++ b/app/views/assignee_mailer/assignee_mail.text.erb
@@ -1,0 +1,16 @@
+Dear <%= @user.name %>,
+
+you've been assigned the following issue:
+
+<%= @issue.to_param %>: <%= @issue.title %>
+<%= "-" * 80 %>
+<%= @issue.description %>
+
+PLEASE NOTE:
+<% if @time_left %>
+this issue will auto-escalate if you don't acknowledge it within
+<%= distance_of_time_in_words(Time.now, @time_left.minutes.from_now)
+%>, by <%= @time_left.minutes.from_now %>!
+<% else %>
+this issue will not auto-escalate!
+<% end %>

--- a/app/views/assignee_mailer/escalated_mail.text.erb
+++ b/app/views/assignee_mailer/escalated_mail.text.erb
@@ -1,0 +1,4 @@
+Dear <%= @user.name %>,
+
+Issue <%= @issue.to_param %> has been escalated and you are no longer assigned
+to it.

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -14,7 +14,8 @@ Escalator::Application.configure do
   config.action_controller.perform_caching = false
 
   # Don't care if the mailer can't send
-  config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.raise_delivery_errors = true
 
   # Print deprecation notices to the Rails logger
   config.active_support.deprecation = :log

--- a/lib/escalation_job.rb
+++ b/lib/escalation_job.rb
@@ -16,9 +16,12 @@ class EscalationJob < Struct.new(:issue_id)
 
     oncall = escalate_to.rotation.users.first
     unless issue.assignee == oncall
+      old_assignee = issue.assignee
       issue.assignee = oncall
       issue.save
+
       AssigneeMailer.assignee_mail(oncall, issue, check_after).deliver
+      AssigneeMailer.escalated_mail(old_assignee, issue).deliver if old_assignee
       #Delayed::Job.enqueue(NotificationJob.new(oncall.to_param))
     end
   end

--- a/test/fixtures/issues.yml
+++ b/test/fixtures/issues.yml
@@ -7,30 +7,30 @@ valid:
   posted_at: <%= 1.minutes.ago %>
   status: present
 
-1-1:
+one:
   escalation_policy: one
-  title: issue 1-1
+  title: issue one
   description: 
   posted_at: <%= 1.minutes.ago %>
   status: new
 
-1-2:
+two:
   escalation_policy: one
-  title: issue 1-2
+  title: issue two
   description: 
   posted_at: <%= 5.minutes.ago %>
   status: new
 
-2-1:
+three:
   escalation_policy: two
-  title: issue 2-1
+  title: issue three
   description: 
   posted_at: <%= 1.minutes.ago %>
   status: new
 
-2-2:
+four:
   escalation_policy: two
-  title: issue 2-2
+  title: issue four
   description: 
   posted_at: <%= 5.minutes.ago %>
   status: new

--- a/test/functional/assignee_mailer_test.rb
+++ b/test/functional/assignee_mailer_test.rb
@@ -1,0 +1,33 @@
+require 'test_helper'
+
+class AssigneeMailerTest < ActionMailer::TestCase
+  setup do
+    @user = users(:one)
+    @issue = issues(:one)
+  end
+
+  test "should send assignee_mail" do
+    assert_difference("ActionMailer::Base.deliveries.size", 1) do
+      AssigneeMailer.assignee_mail(@user, @issue).deliver
+    end
+
+    mail = ActionMailer::Base.deliveries.first
+
+    assert_equal @user.email, mail.to[0]
+    assert_equal "Issue #{@issue.to_param} has been assigned to you!", mail.subject
+    assert_match /Dear #{@user.name}/, mail.body
+  end
+
+  test "should send escalated_mail" do
+    assert_difference("ActionMailer::Base.deliveries.size", 1) do
+      AssigneeMailer.escalated_mail(@user, @issue).deliver
+    end
+
+    mail = ActionMailer::Base.deliveries.first
+
+    assert_equal @user.email, mail.to[0]
+    assert_equal "Issue #{@issue.to_param} has been escalated!", mail.subject
+    assert_match /Dear #{@user.name}/, mail.body
+  end
+
+end


### PR DESCRIPTION
Just a simple exercise using ActionMailer, for later reference. In reality this should go through the alerting steps of a rotation membership first in order to find the email address to use, if any (with a possible fall-back to the email address of the account).
