### PR TITLE
Set up Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: ruby
+rvm:
+  - 1.8.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: ruby
-bunder_args: --without development
+bundler_args: --without development
 rvm:
   - 1.8.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: ruby
+bunder_args: --without development
 rvm:
   - 1.8.7

--- a/config/database.yml
+++ b/config/database.yml
@@ -14,9 +14,8 @@ development:
 # Do not set this db to the same as development or production.
 test:
   adapter: sqlite3
-  database: db/test.sqlite3
-  pool: 5
-  timeout: 5000
+  database: ":memory:"
+  timeout: 500
 
 production:
   adapter: sqlite3

--- a/config/initializers/in_memory_database.rb
+++ b/config/initializers/in_memory_database.rb
@@ -1,0 +1,11 @@
+def in_memory_sqlite?
+  Rails.env == "test" and
+    ActiveRecord::Base.connection.class == ActiveRecord::ConnectionAdapters::SQLiteAdapter ||
+      ActiveRecord::Base.connection.class == ActiveRecord::ConnectionAdapters::SQLite3Adapter and
+    Rails.configuration.database_configuration['test']['database'] = ':memory:'
+end
+
+if in_memory_sqlite?
+  puts "Creating SQLite in-memory database."
+  load "#{Rails.root}/db/schema.rb"
+end


### PR DESCRIPTION
Changed the test environment to use in-memory SQLite for speed, excluded `:development` group from Gemfile for Travis (this shaves 11 seconds off the build).
