### PR TITLE
Add RotationJob.

### DIFF
--- a/app/models/rotation.rb
+++ b/app/models/rotation.rb
@@ -1,6 +1,17 @@
 class Rotation < ActiveRecord::Base
   has_many :rotation_memberships
   has_many :users, :through => :rotation_memberships, :order => "rank"
+  # Handle to the currently pending RotationJob.
+  # TODO(hermannloose): If :rotate_every is changed, this job should be killed.
+  belongs_to :delayed_job
 
   validates :name, :presence => true
+  validates :rotate_every, :numericality => {
+    :only_integer => true,
+    # Schedule RotationJobs at least 15 minutes apart.
+    #
+    # Smaller values are not really practical and I would like to avoid
+    # concurrency bugs at least for now. -hermannloose
+    :greater_than_or_equal_to => 900
+  }
 end

--- a/db/migrate/20120125083755_add_scheduling_info_to_rotations.rb
+++ b/db/migrate/20120125083755_add_scheduling_info_to_rotations.rb
@@ -1,0 +1,8 @@
+class AddSchedulingInfoToRotations < ActiveRecord::Migration
+  def change
+    change_table :rotations do |t|
+      t.integer :rotate_every
+      t.references :delayed_job
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20120119195707) do
+ActiveRecord::Schema.define(:version => 20120125083755) do
 
   create_table "alerting_steps", :force => true do |t|
     t.integer  "delay_minutes"
@@ -129,6 +129,8 @@ ActiveRecord::Schema.define(:version => 20120119195707) do
     t.string   "name"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.integer  "rotate_every"
+    t.integer  "delayed_job_id"
   end
 
   create_table "users", :force => true do |t|

--- a/lib/rotation_job.rb
+++ b/lib/rotation_job.rb
@@ -1,0 +1,22 @@
+class RotationJob < Struct.new(:rotation_id)
+  def before(job)
+    # Use job.run_at instead of Time.now to prevent drift.
+    @schedule_base = job.run_at
+  end
+
+  def perform
+    rotation = Rotation.includes(:rotation_memberships).find(rotation_id)
+
+    memberships = rotation.rotation_memberships
+    memberships.each do |membership|
+      membership.rank = (membership.rank + 1) % memberships.size
+    end
+    RotationMembership.transaction do
+      memberships.each { |membership| membership.save! }
+    end
+
+    Delayed::Job.enqueue(RotationJob.new(rotation_id),
+        :priority => 0,
+        :run_at => rotation.rotate_every.seconds.since(@schedule_base))
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -26,4 +26,18 @@ FactoryGirl.define do
     password 'password'
     roles [ Factory(:user_role) ]
   end
+
+  # Rotations
+  factory :rotation do
+    sequence :name do |n|
+      "Rotation ##{n}"
+    end
+    rotate_every 1000
+  end
+
+  factory :rotation_membership do
+    rotation Factory(:rotation)
+    user Factory(:user)
+    rank 0
+  end
 end

--- a/spec/lib/rotation_job_spec.rb
+++ b/spec/lib/rotation_job_spec.rb
@@ -1,0 +1,60 @@
+require 'spec_helper'
+require 'rotation_job'
+
+describe RotationJob do
+  describe "#perform" do
+    before :each do
+      @now = Time.now
+      @rotation = Factory(:rotation)
+    end
+
+    it "should rotate the users in the rotation" do
+      users = FactoryGirl.create_list(:user, 5)
+      rank = 0
+      users.each do |user|
+        Factory(:rotation_membership,
+            :rotation => @rotation,
+            :user => user,
+            :rank => rank)
+        rank += 1
+      end
+
+      Delayed::Job.enqueue(RotationJob.new(@rotation.to_param))
+
+      successful, failed = Delayed::Worker.new.work_off
+
+      successful.should eql(1)
+      failed.should eql(0)
+
+      # TODO(hermannloose): Change to use Array#rotate with Ruby 1.9.3.
+      @rotation.reload.users.should eql(users[4..4] + users[0..3])
+    end
+
+    it "should schedule a new RotationJob" do
+      Delayed::Job.enqueue(RotationJob.new(@rotation.to_param))
+
+      successful, failed = Delayed::Worker.new.work_off
+
+      successful.should eql(1)
+      failed.should eql(0)
+
+      Delayed::Job.count.should eql(1)
+      Delayed::Job.first.name.should eql("RotationJob")
+    end
+
+    it "should not drift" do
+      # rotate_every defaults to 1000 in factory
+      schedule_base = 500.seconds.until(@now)
+      Delayed::Job.enqueue(RotationJob.new(@rotation.to_param),
+          :priority => 0,
+          :run_at => schedule_base)
+
+      successful, failed = Delayed::Worker.new.work_off
+
+      successful.should eql(1)
+      failed.should eql(0)
+
+      Delayed::Job.first.run_at.should eql(500.seconds.since(@now))
+    end
+  end
+end

--- a/spec/models/rotation_spec.rb
+++ b/spec/models/rotation_spec.rb
@@ -3,6 +3,15 @@ require 'spec_helper'
 describe Rotation do
   it { should have_many :rotation_memberships }
   it { should have_many(:users).through(:rotation_memberships) }
+  it "should have a handle to the currently pending RotationJob" do
+    should belong_to(:delayed_job)
+  end
 
   it { should validate_presence_of :name }
+  it { should validate_numericality_of :rotate_every }
+  it { should_not allow_value(-1).for(:rotate_every) }
+  it { should_not allow_value(0).for(:rotate_every) }
+  it { should_not allow_value(1.1).for(:rotate_every) }
+  it { should_not allow_value(899).for(:rotate_every) }
+  it { should allow_value(900).for(:rotate_every) }
 end


### PR DESCRIPTION
Proposal for a job that rotates the users in a rotation. Killing a pending job upon changing the schedule of a rotation is not yet implemented, but maybe this could already go in as a smaller change and I'll build upon it.
