### PR TITLE
Don't require factory_girl_rails automatically.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ end
 group :development, :test do
   # Anything above 1.4.0 seems to be broken using RubyGems 1.3.7, the current
   # default in Ubuntu 11.04.
-  gem 'factory_girl_rails', '1.4.0'
+  gem 'factory_girl_rails', '1.4.0', :require => false
   gem 'mocha'
   gem 'rspec-rails'
   gem 'shoulda-matchers'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@ require 'rspec/rails'
 require 'rspec/autorun'
 require 'shoulda-matchers'
 
+require 'factory_girl_rails'
 require 'declarative_authorization/maintenance'
 require 'authorization_helper'
 


### PR DESCRIPTION
Without this, rake db:reset, rake db:migrate, rails console and other things
just break, as factory_girl seems be invoked before the corresponding tables
are in the database (after dropping it).
