### PR TITLE
Fix Autotest configuration and GoogleClientLoginCredentials spec.

### DIFF
--- a/.autotest
+++ b/.autotest
@@ -1,3 +1,3 @@
 Autotest.add_hook :initialize do |at|
-  %w( .git coverage log rspec-results.html ).each { |exception| at.add_exception(exception) }
+  %w( .git/ coverage/ log/ rspec-results.html ).each { |exception| at.add_exception(exception) }
 end

--- a/spec/controllers/google_client_login_controller_spec.rb
+++ b/spec/controllers/google_client_login_controller_spec.rb
@@ -1,9 +1,7 @@
 require 'spec_helper'
 
+# TODO(hermannloose): Make this more comprehensive.
 describe GoogleClientLoginController do
-  render_views
-  setup_mapping
-
   before :each do
     @admin = Factory(:admin)
     sign_in @admin

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -88,4 +88,10 @@ FactoryGirl.define do
     status :open
     posted_at Time.zone.now
   end
+
+  # Google ClientLogin credentials
+  factory :google_client_login_credentials do
+    email "user@example.com"
+    token "deadbeef"
+  end
 end

--- a/spec/models/google_client_login_credentials_spec.rb
+++ b/spec/models/google_client_login_credentials_spec.rb
@@ -1,9 +1,7 @@
 require 'spec_helper'
 
 describe GoogleClientLoginCredentials do
-  fixtures :google_client_login_credentials
-
-  subject { google_client_login_credentials(:valid) }
+  subject { FactoryGirl.create(:google_client_login_credentials) }
 
   it { should validate_presence_of :email }
   it { should validate_presence_of :token }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,9 +29,6 @@ RSpec.configure do |config|
   config.include Authorization::TestHelper, :type => :controller
   config.extend AuthorizationHelper, :type => :controller
 
-  # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_path = "#{::Rails.root}/spec/fixtures"
-
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.


### PR DESCRIPTION
Autotest was skipping this spec due to a slight misconfiguration, thus I missed it in #32, as Travis was a bit slow sending out email. Anyway, this should fix it.
