### PR TITLE
Upgrade to Bundler 1.1 on Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,8 @@ rvm:
   - 1.9.2
   - 1.9.3
 
+before_install:
+  - gem install bundler
+
 before_script:
   - "rake db:migrate"


### PR DESCRIPTION
See http://about.travis-ci.org/blog/the-great-bundler-1-1-upgrade/ for info.

Noticeable improvement, [8:01](http://travis-ci.org/#!/hermannloose/escalator/builds/828041) versus [12:31](http://travis-ci.org/#!/hermannloose/escalator/builds/730310) (total duration of three builds each). The Gemfile still needs some sorting out though, building eventmachine with native extensions takes a few seconds while it's never needed in tests.
